### PR TITLE
Create .npmrc file

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+registry=https://registry.npmjs.org/


### PR DESCRIPTION
Wanted to add a project-specific `.npmrc` file.

This is mainly because my laptop is configured to use my company's package registry by default. This tells yarn and npm to use the regular registry instead.